### PR TITLE
Corrected interfaces.

### DIFF
--- a/contracts/interface/IFactory.sol
+++ b/contracts/interface/IFactory.sol
@@ -16,6 +16,4 @@ interface IFactory {
   function getPair(address tokenA, address token, bool stable) external view returns (address);
 
   function createPair(address tokenA, address tokenB, bool stable) external returns (address pair);
-
-  function allPairsLength() external view returns (uint);
 }

--- a/contracts/interface/IFactory.sol
+++ b/contracts/interface/IFactory.sol
@@ -16,4 +16,6 @@ interface IFactory {
   function getPair(address tokenA, address token, bool stable) external view returns (address);
 
   function createPair(address tokenA, address tokenB, bool stable) external returns (address pair);
+
+  function allPairsLength() external view returns (uint);
 }

--- a/contracts/interface/IPair.sol
+++ b/contracts/interface/IPair.sol
@@ -25,9 +25,17 @@ interface IPair {
 
   function claimFees() external returns (uint, uint);
 
-  function tokens() external returns (address, address);
+  function tokens() external view returns (address, address);
 
-  function token0() external returns (address);
+  function token0() external view returns (address);
 
-  function token1() external returns (address);
+  function token1() external view returns (address);
+
+  function stable() external view returns (bool);
+
+  function sync() external;
+
+  function name() external pure returns (string memory);
+
+  function symbol() external pure returns (string memory);
 }

--- a/contracts/interface/IPair.sol
+++ b/contracts/interface/IPair.sol
@@ -32,10 +32,4 @@ interface IPair {
   function token1() external view returns (address);
 
   function stable() external view returns (bool);
-
-  function sync() external;
-
-  function name() external view returns (string memory);
-
-  function symbol() external view returns (string memory);
 }

--- a/contracts/interface/IPair.sol
+++ b/contracts/interface/IPair.sol
@@ -35,7 +35,7 @@ interface IPair {
 
   function sync() external;
 
-  function name() external pure returns (string memory);
+  function name() external view returns (string memory);
 
-  function symbol() external pure returns (string memory);
+  function symbol() external view returns (string memory);
 }

--- a/contracts/interface/IRouter.sol
+++ b/contracts/interface/IRouter.sol
@@ -3,7 +3,14 @@
 pragma solidity ^0.8.13;
 
 interface IRouter {
+    struct Route {
+        address from;
+        address to;
+        bool stable;
+    }
+
     function factory() external view returns (address);
+
     function WMATIC() external view returns (address);
 
     function addLiquidity(
@@ -17,6 +24,7 @@ interface IRouter {
         address to,
         uint deadline
     ) external returns (uint amountA, uint amountB, uint liquidity);
+    
     function addLiquidityMATIC(
         address token,
         bool stable,
@@ -26,6 +34,7 @@ interface IRouter {
         address to,
         uint deadline
     ) external payable returns (uint amountToken, uint amountMATIC, uint liquidity);
+    
     function removeLiquidity(
         address tokenA,
         address tokenB,
@@ -36,6 +45,7 @@ interface IRouter {
         address to,
         uint deadline
     ) external returns (uint amountA, uint amountB);
+
     function removeLiquidityMATIC(
         address token,
         bool stable,
@@ -45,6 +55,7 @@ interface IRouter {
         address to,
         uint deadline
     ) external returns (uint amountToken, uint amountMATIC);
+
     function removeLiquidityWithPermit(
         address tokenA,
         address tokenB,
@@ -56,6 +67,7 @@ interface IRouter {
         uint deadline,
         bool approveMax, uint8 v, bytes32 r, bytes32 s
     ) external returns (uint amountA, uint amountB);
+
     function removeLiquidityMATICWithPermit(
         address token,
         bool stable,
@@ -66,55 +78,187 @@ interface IRouter {
         uint deadline,
         bool approveMax, uint8 v, bytes32 r, bytes32 s
     ) external returns (uint amountToken, uint amountMATIC);
+
     function swapExactTokensForTokens(
         uint amountIn,
         uint amountOutMin,
-        address[] calldata path,
+        Route[] calldata routes,
         address to,
         uint deadline
     ) external returns (uint[] memory amounts);
+
+    //This is corrected but this method is not implemented in DystRouter01.sol
     function swapTokensForExactTokens(
         uint amountOut,
         uint amountInMax,
-        address[] calldata path,
+        Route[] calldata routes,
         address to,
         uint deadline
     ) external returns (uint[] memory amounts);
-    function swapExactMATICForTokens(uint amountOutMin, address[] calldata path, address to, uint deadline)
-        external
-        payable
-        returns (uint[] memory amounts);
-    function swapTokensForExactMATIC(uint amountOut, uint amountInMax, address[] calldata path, address to, uint deadline)
-        external
-        returns (uint[] memory amounts);
-    function swapExactTokensForMATIC(uint amountIn, uint amountOutMin, address[] calldata path, address to, uint deadline)
-        external
-        returns (uint[] memory amounts);
-    function swapMATICForExactTokens(uint amountOut, address[] calldata path, address to, uint deadline)
-        external
-        payable
-        returns (uint[] memory amounts);
 
-  function quoteRemoveLiquidity(
-    address tokenA,
-    address tokenB,
-    bool stable,
-    uint liquidity
-  ) external view returns (uint amountA, uint amountB);
+    function swapExactMATICForTokens(
+        uint amountOutMin,
+        Route[] calldata routes,
+        address to,
+        uint deadline
+    ) external payable returns (uint[] memory amounts);
+
+    //This is corrected but this method is not implemented in DystRouter01.sol
+    function swapTokensForExactMATIC(
+        uint amountOut,
+        uint amountInMax,
+        Route[] calldata routes,
+        address to,
+        uint deadline
+    ) external returns (uint[] memory amounts);
+
+    function swapExactTokensForMATIC(
+        uint amountIn,
+        uint amountOutMin,
+        Route[] calldata routes,
+        address to,
+        uint deadline
+    ) external returns (uint[] memory amounts);
+
+    //This is corrected but this method is not implemented in DystRouter01.sol
+    function swapMATICForExactTokens(
+        uint amountOut,
+        Route[] calldata routes,
+        address to,
+        uint deadline
+    ) external payable returns (uint[] memory amounts);
+
+    function quoteRemoveLiquidity(
+        address tokenA,
+        address tokenB,
+        bool stable,
+        uint liquidity
+    ) external view returns (uint amountA, uint amountB);
+
     function quoteAddLiquidity(
-    address tokenA,
-    address tokenB,
-    bool stable,
-    uint amountADesired,
-    uint amountBDesired
-  ) external view returns (uint amountA, uint amountB, uint liquidity);
+        address tokenA,
+        address tokenB,
+        bool stable,
+        uint amountADesired,
+        uint amountBDesired
+    )
+        external
+        view
+        returns (
+            uint amountA,
+            uint amountB,
+            uint liquidity
+        );
 
-    function pairFor(address tokenA, address tokenB, bool stable) external view returns (address pair);
-    function sortTokens(address tokenA, address tokenB) external pure returns (address token0, address token1);
-    function quoteLiquidity(uint amountA, uint reserveA, uint reserveB) external pure returns (uint amountB);
-    function getAmountOut(uint amountIn, uint reserveIn, uint reserveOut) external pure returns (uint amountOut, bool stable);
-    function getAmountIn(uint amountOut, uint reserveIn, uint reserveOut) external pure returns (uint amountIn, bool stable);
-    function getAmountsOut(uint amountIn, address[] calldata path) external view returns (uint[] memory amounts);
-    function getAmountsIn(uint amountOut, address[] calldata path) external view returns (uint[] memory amounts);
-    function getReserves(address tokenA, address tokenB, bool stable) external view returns (uint reserveA, uint reserveB);
+    function pairFor(
+        address tokenA,
+        address tokenB,
+        bool stable
+    ) external view returns (address pair);
+
+    function sortTokens(address tokenA, address tokenB)
+        external
+        pure
+        returns (address token0, address token1);
+
+    function quoteLiquidity(
+        uint amountA,
+        uint reserveA,
+        uint reserveB
+    ) external pure returns (uint amountB);
+
+    function getAmountOut(
+        uint amountIn,
+        address tokenIn,
+        address tokenOut
+    ) external view returns (uint amount, bool stable);
+
+    function getAmountIn(
+        uint amountOut,
+        uint reserveIn,
+        uint reserveOut
+    ) external pure returns (uint amountIn, bool stable);
+
+    function getAmountsOut(uint amountIn, Route[] memory routes)
+        external
+        view
+        returns (uint[] memory amounts);
+
+    //This is corrected but this method is not implemented in DystRouter01.sol
+    function getAmountsIn(uint amountOut, Route[] memory routes)
+        external
+        view
+        returns (uint[] memory amounts);
+
+    function getReserves(
+        address tokenA,
+        address tokenB,
+        bool stable
+    ) external view returns (uint reserveA, uint reserveB);
+
+    function getExactAmountOut(
+        uint amountIn,
+        address tokenIn,
+        address tokenOut,
+        bool stable
+    ) external view returns (uint amount);
+
+    function isPair(address pair) external view returns (bool);
+
+    function swapExactTokensForTokensSimple(
+        uint amountIn,
+        uint amountOutMin,
+        address tokenFrom,
+        address tokenTo,
+        bool stable,
+        address to,
+        uint deadline
+    ) external returns (uint[] memory amounts);
+
+    function swapExactTokensForMATICSupportingFeeOnTransferTokens(
+        uint amountIn,
+        uint amountOutMin,
+        Route[] calldata routes,
+        address to,
+        uint deadline
+    ) external;
+
+    function swapExactMATICForTokensSupportingFeeOnTransferTokens(
+        uint amountOutMin,
+        Route[] calldata routes,
+        address to,
+        uint deadline
+    ) external payable;
+
+    function swapExactTokensForTokensSupportingFeeOnTransferTokens(
+        uint amountIn,
+        uint amountOutMin,
+        Route[] calldata routes,
+        address to,
+        uint deadline
+    ) external;
+
+    function removeLiquidityMATICWithPermitSupportingFeeOnTransferTokens(
+        address token,
+        bool stable,
+        uint liquidity,
+        uint amountTokenMin,
+        uint amountFTMMin,
+        address to,
+        uint deadline,
+        bool approveMax,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) external returns (uint amountToken, uint amountFTM);
+
+    function removeLiquidityMATICSupportingFeeOnTransferTokens(
+        address token,
+        bool stable,
+        uint liquidity,
+        uint amountTokenMin,
+        uint amountFTMMin,
+        address to,
+        uint deadline
+    ) external returns (uint amountToken, uint amountFTM);
 }


### PR DESCRIPTION
This PR contains - 
- Fixed interface for IRouter. (Corrected address [] path to Route[] calldata routes)
- Added more methods in interfaces from the contract. (This interface is not inherited anywhere, so adding these methods doesn't cause an issue)
- Correct interface for IPair. (Added method for `stable` and other minor updates.)